### PR TITLE
Fix vfx and sound rotation : Fix/Programmation

### DIFF
--- a/Assets/Prefabs/WorldComponents/FallingBox.prefab
+++ b/Assets/Prefabs/WorldComponents/FallingBox.prefab
@@ -171,7 +171,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5666446833952311804}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4612776b4a503384890ce87978186783, type: 3}
   m_Name: 
@@ -181,7 +181,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 2195462322752959078, guid: 8be76a73d47cb55469fc5c0c3fdd8f25, type: 3}
         m_TargetAssemblyTypeName: Events, Assembly-CSharp
-        m_MethodName: spawnFallingBoxShockEffect
+        m_MethodName: SpawnFallingBoxShockEffect
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Prefabs/WorldComponents/Pollos.prefab
+++ b/Assets/Prefabs/WorldComponents/Pollos.prefab
@@ -217,7 +217,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 2195462322752959078, guid: 8be76a73d47cb55469fc5c0c3fdd8f25, type: 3}
         m_TargetAssemblyTypeName: Events, Assembly-CSharp
-        m_MethodName: spawnPollosShockEffect
+        m_MethodName: SpawnPollosShockEffect
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Prefabs/Worlds/World1.prefab
+++ b/Assets/Prefabs/Worlds/World1.prefab
@@ -185,7 +185,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _rotationDuration: 0.2
-  _rotableChild: {fileID: 4984774974986292881}
+  _rotableChild: {fileID: 3909547111023414187}
   _stormEffect: {fileID: 2100000, guid: 8251dd813068e6a408526df7a699b7bb, type: 2}
   _alphaCurve:
     serializedVersion: 2

--- a/Assets/Prefabs/Worlds/World2.prefab
+++ b/Assets/Prefabs/Worlds/World2.prefab
@@ -114,7 +114,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _rotationDuration: 0.2
-  _rotableChild: {fileID: 4984774974986292881}
+  _rotableChild: {fileID: 3909547111023414187}
   _stormEffect: {fileID: 2100000, guid: 8251dd813068e6a408526df7a699b7bb, type: 2}
   _alphaCurve:
     serializedVersion: 2

--- a/Assets/Prefabs/Worlds/World3.prefab
+++ b/Assets/Prefabs/Worlds/World3.prefab
@@ -123,7 +123,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _rotationDuration: 0.2
-  _rotableChild: {fileID: 4984774974986292881}
+  _rotableChild: {fileID: 3909547111023414187}
   _stormEffect: {fileID: 2100000, guid: 8251dd813068e6a408526df7a699b7bb, type: 2}
   _alphaCurve:
     serializedVersion: 2

--- a/Assets/Prefabs/Worlds/World4.prefab
+++ b/Assets/Prefabs/Worlds/World4.prefab
@@ -134,7 +134,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _rotationDuration: 0.2
-  _rotableChild: {fileID: 4984774974986292881}
+  _rotableChild: {fileID: 3909547111023414187}
   _stormEffect: {fileID: 2100000, guid: 8251dd813068e6a408526df7a699b7bb, type: 2}
   _alphaCurve:
     serializedVersion: 2

--- a/Assets/Prefabs/Worlds/World5.prefab
+++ b/Assets/Prefabs/Worlds/World5.prefab
@@ -134,7 +134,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _rotationDuration: 0.2
-  _rotableChild: {fileID: 4984774974986292881}
+  _rotableChild: {fileID: 3909547111023414187}
   _stormEffect: {fileID: 2100000, guid: 8251dd813068e6a408526df7a699b7bb, type: 2}
   _alphaCurve:
     serializedVersion: 2

--- a/Assets/Prefabs/Worlds/World6.prefab
+++ b/Assets/Prefabs/Worlds/World6.prefab
@@ -121,7 +121,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _rotationDuration: 0.2
-  _rotableChild: {fileID: 4984774974986292881}
+  _rotableChild: {fileID: 3909547111023414187}
   _stormEffect: {fileID: 2100000, guid: 8251dd813068e6a408526df7a699b7bb, type: 2}
   _alphaCurve:
     serializedVersion: 2

--- a/Assets/Prefabs/Worlds/World7.prefab
+++ b/Assets/Prefabs/Worlds/World7.prefab
@@ -132,7 +132,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _rotationDuration: 0.2
-  _rotableChild: {fileID: 4984774974986292881}
+  _rotableChild: {fileID: 3909547111023414187}
   _stormEffect: {fileID: 2100000, guid: 8251dd813068e6a408526df7a699b7bb, type: 2}
   _alphaCurve:
     serializedVersion: 2

--- a/Assets/Resources/vfxGraphs/featherLoss.vfx
+++ b/Assets/Resources/vfxGraphs/featherLoss.vfx
@@ -346,7 +346,7 @@ MonoBehaviour:
   particlePerStripCount: 32
   needsComputeBounds: 0
   boundsMode: 0
-  m_Space: 1
+  m_Space: 0
 --- !u!114 &8926484042661614756
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Benji/InGame.unity
+++ b/Assets/Scenes/Benji/InGame.unity
@@ -2097,6 +2097,22 @@ PrefabInstance:
       propertyPath: '_audioEffectsSerializable.Array.data[8].clips.Array.data[0]'
       value: 
       objectReference: {fileID: 8300000, guid: b111d8579d65ec342a9bbfbdb2b18149, type: 3}
+    - target: {fileID: 2195462322752959078, guid: 8be76a73d47cb55469fc5c0c3fdd8f25, type: 3}
+      propertyPath: _smokeEffect._prefab
+      value: 
+      objectReference: {fileID: 5468722911704688411, guid: 29a8ae1befe93ab4c9211df58599e901, type: 3}
+    - target: {fileID: 2195462322752959078, guid: 8be76a73d47cb55469fc5c0c3fdd8f25, type: 3}
+      propertyPath: _smokeEffect._duration
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2195462322752959078, guid: 8be76a73d47cb55469fc5c0c3fdd8f25, type: 3}
+      propertyPath: _pollosShockVFX._prefab
+      value: 
+      objectReference: {fileID: 7931719009794597227, guid: e83e924266991824babf81fbefdea8a7, type: 3}
+    - target: {fileID: 2195462322752959078, guid: 8be76a73d47cb55469fc5c0c3fdd8f25, type: 3}
+      propertyPath: _pollosShockVFX._duration
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 3259950549411156748, guid: 8be76a73d47cb55469fc5c0c3fdd8f25, type: 3}
       propertyPath: _pauseUI
       value: 

--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -92,7 +92,9 @@ public class	AudioManager : MonoBehaviour
 
 		if (audioClip == null)
 			return ;
-		AudioSource	audioSource = Instantiate(_audioSourcePrefab, audioSourcePoint, Quaternion.identity);
+		if (!Level.TryAndGetInstance(out Level level))
+			return ;
+		AudioSource	audioSource = Instantiate(_audioSourcePrefab, audioSourcePoint, Quaternion.identity, level.GetRotableChild());
 		
 		audioSource.clip = audioClip;
 		audioSource.volume = volume;

--- a/Assets/Scripts/Events.cs
+++ b/Assets/Scripts/Events.cs
@@ -1,5 +1,16 @@
+using System;
 using UnityEngine;
-using UnityEngine.VFX;
+
+[Serializable]
+public class Effect {
+	[SerializeField]
+	private GameObject	_prefab;
+	[SerializeField]
+	private float		_duration;
+	
+	public GameObject	Prefab { get => _prefab; }
+	public float		Duration { get => _duration; }
+};
 
 /// <summary>This class is a singleton that stores all the static event functions
 /// that can be assigned to a prefab</summary>
@@ -8,9 +19,9 @@ public class Events : MonoBehaviour
 	private static Events	_instance;
 
 	[SerializeField]
-	private Animator		_smokeEffect;
+	private Effect			_smokeEffect;
 	[SerializeField]
-	private VisualEffect	_pollosShockVFX;
+	private Effect			_pollosShockVFX;
 	
 	private void	Start()
 	{
@@ -21,6 +32,14 @@ public class Events : MonoBehaviour
 			return ;
 		}
 		_instance = this;
+	}
+	
+	private static void	InstantiateTemporaryEffect(Effect effect, Transform transform)
+	{
+		if (!Level.TryAndGetInstance(out Level level))
+			return ;
+		GameObject	instance = Instantiate(effect.Prefab, transform.position, transform.rotation, level.GetRotableChild());
+		Destroy(instance, effect.Duration);
 	}
 
 	/// <summary>Spawn a smoke effect and play a falling box sound.</summary>
@@ -33,12 +52,7 @@ public class Events : MonoBehaviour
 			return;
 		}
 
-		if (!Level.TryAndGetInstance(out Level level))
-			return ;
-		Animator	effect = Instantiate(_instance._smokeEffect , transform.position,
-				transform.rotation, level.GetRotableChild());
-		float effectDuration = effect.GetCurrentAnimatorStateInfo(0).length;
-		Destroy(effect.gameObject, effectDuration);
+		InstantiateTemporaryEffect(_instance._smokeEffect, transform);
 		if (AudioManager.TryAndGetInstance(out AudioManager audioManager))
 			audioManager.PlayAudioEffect("BoxFall", transform.position, 1);
 	}
@@ -52,21 +66,7 @@ public class Events : MonoBehaviour
 			Debug.LogError("There is no instance of the Events class but an event function has been called !");
 			return;
 		}
-		if (!Level.TryAndGetInstance(out Level level))
-			return ;
-		{
-			Animator	effect = Instantiate(_instance._smokeEffect , transform.position,
-					transform.rotation, level.GetRotableChild());
-			float effectDuration = effect.GetCurrentAnimatorStateInfo(0).length;
-
-			Destroy(effect.gameObject, effectDuration);
-		}
-		{
-			VisualEffect	vfx = Instantiate(_instance._pollosShockVFX, transform.position,
-					transform.rotation, level.GetRotableChild());
-			float	effectDuration = 2.0f;
-			
-			Destroy(vfx.gameObject, effectDuration);
-		}
+		InstantiateTemporaryEffect(_instance._smokeEffect, transform);
+		InstantiateTemporaryEffect(_instance._pollosShockVFX, transform);
 	}
 }

--- a/Assets/Scripts/Events.cs
+++ b/Assets/Scripts/Events.cs
@@ -1,6 +1,8 @@
 using System;
 using UnityEngine;
 
+/// <summary>This class stores all the variables necessary for an Effect :
+/// its prefab and duration.</summary>
 [Serializable]
 public class Effect {
 	[SerializeField]
@@ -34,6 +36,9 @@ public class Events : MonoBehaviour
 		_instance = this;
 	}
 	
+	/// <summary>Instantiate the Effect.Prefab and destroy it after Effect.Duration seconds.
+	/// The parent of the instanciated effect will be the current level rotable</summary>
+	/// <param name="transform">The effect will be instanciated with the transform.position and rotation.</param>
 	private static void	InstantiateTemporaryEffect(Effect effect, Transform transform)
 	{
 		if (!Level.TryAndGetInstance(out Level level))

--- a/Assets/Scripts/Events.cs
+++ b/Assets/Scripts/Events.cs
@@ -25,40 +25,45 @@ public class Events : MonoBehaviour
 
 	/// <summary>Spawn a smoke effect and play a falling box sound.</summary>
 	/// <param name="gameObject">The box gameObject.</param>
-	public static void	SpawnFallingBoxShockEffect(GameObject gameObject)
+	public static void	SpawnFallingBoxShockEffect(Transform transform)
 	{
 		if (_instance == null)
 		{
 			Debug.LogError("There is no instance of the Events class but an eventt function has been called !");
 			return;
 		}
-		Animator	effect = Instantiate(_instance._smokeEffect , gameObject.transform.position,
-				gameObject.transform.rotation);
+
+		if (!Level.TryAndGetInstance(out Level level))
+			return ;
+		Animator	effect = Instantiate(_instance._smokeEffect , transform.position,
+				transform.rotation, level.GetRotableChild());
 		float effectDuration = effect.GetCurrentAnimatorStateInfo(0).length;
 		Destroy(effect.gameObject, effectDuration);
 		if (AudioManager.TryAndGetInstance(out AudioManager audioManager))
-			audioManager.PlayAudioEffect("BoxFall", gameObject.transform.position, 1);
+			audioManager.PlayAudioEffect("BoxFall", transform.position, 1);
 	}
 	
 	/// <summary>Spawn a smoke effect, a feather vfx and a pollos hurt sound.</summary>
 	/// <param name="gameObject">The pollos gameObject.</param>
-	public static void	SpawnPollosShockEffect(GameObject gameObject)
+	public static void	SpawnPollosShockEffect(Transform transform)
 	{
 		if (_instance == null)
 		{
 			Debug.LogError("There is no instance of the Events class but an event function has been called !");
 			return;
 		}
+		if (!Level.TryAndGetInstance(out Level level))
+			return ;
 		{
-			Animator	effect = Instantiate(_instance._smokeEffect , gameObject.transform.position,
-					gameObject.transform.rotation);
+			Animator	effect = Instantiate(_instance._smokeEffect , transform.position,
+					transform.rotation, level.GetRotableChild());
 			float effectDuration = effect.GetCurrentAnimatorStateInfo(0).length;
 
 			Destroy(effect.gameObject, effectDuration);
 		}
 		{
-			VisualEffect	vfx = Instantiate(_instance._pollosShockVFX, gameObject.transform.position,
-					gameObject.transform.rotation);
+			VisualEffect	vfx = Instantiate(_instance._pollosShockVFX, transform.position,
+					transform.rotation, level.GetRotableChild());
 			float	effectDuration = 2.0f;
 			
 			Destroy(vfx.gameObject, effectDuration);

--- a/Assets/Scripts/Player/SetActivePop.cs
+++ b/Assets/Scripts/Player/SetActivePop.cs
@@ -2,20 +2,10 @@ using UnityEngine;
 
 public class SetActivePop : MonoBehaviour
 {
-    [SerializeField] private GameObject _fade = null;
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
-    {
-        
-    }
+	[SerializeField] private GameObject _fade = null;
 
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
-    public void PlayGame()
-    {
-        _fade.SetActive(true);
-    }
+	public void PlayGame()
+	{
+		_fade.SetActive(true);
+	}
 }

--- a/Assets/Scripts/Player/UIManager.cs
+++ b/Assets/Scripts/Player/UIManager.cs
@@ -1,62 +1,56 @@
 using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-using UnityEngine.UI;
 
 public class UIManager : MonoBehaviour
 {
-    [SerializeField] private GameObject _playButton = null;
-    [SerializeField] private GameObject _quitButton = null;
-    [SerializeField] private GameObject _creditButton = null;
-    [SerializeField] private GameObject _uiCredit= null;
-    [SerializeField] private GameObject _cancelImage = null;
-    [SerializeField] private Animator _animatorFade= null;
-    [SerializeField] private Animator _animatorPlay= null;
+	[SerializeField] private GameObject _playButton = null;
+	[SerializeField] private GameObject _quitButton = null;
+	[SerializeField] private GameObject _creditButton = null;
+	[SerializeField] private GameObject _uiCredit= null;
+	[SerializeField] private GameObject _cancelImage = null;
+	[SerializeField] private Animator _animatorFade= null;
+	[SerializeField] private Animator _animatorPlay= null;
 
 
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
-    {
-        DontDestroyOnLoad(this._animatorFade.transform.parent);
-    }
+	// Start is called once before the first execution of Update after the MonoBehaviour is created
+	void Start()
+	{
+		DontDestroyOnLoad(this._animatorFade.transform.parent);
+	}
 
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
-    public void OnCreditClic()
-    {
-        _uiCredit.SetActive(true);
-        _playButton.SetActive(false);
-        _quitButton.SetActive(false);
-        _creditButton.SetActive(false);
-    }
-    public void OnExitCreditClic()
-    {
-        //_uiCredit.SetActive(false);
-        //_playButton.SetActive(true);
-        //_quitButton.SetActive(true);
-        //_creditButton.SetActive(true);
-    }
-    public IEnumerator PlayGameCoroutine()
-    {
-        _animatorPlay.SetBool("PlayClick",true);
-        _cancelImage.SetActive(true);
-        yield return new WaitForSeconds(8);
-        SceneManager.LoadSceneAsync("InGame");
-    }
-    public void ExitGame()
-    {
-        Application.Quit();
-    }
-    public void OnClic()
-    {
-        if (AudioManager.TryAndGetInstance(out AudioManager audioManager))
-            audioManager.PlayAudioEffect("Clic", gameObject.transform.position, 2);
-    }
-    public void PlayGame()
-    {
-        StartCoroutine(PlayGameCoroutine());
-    }
+	public void OnCreditClic()
+	{
+		_uiCredit.SetActive(true);
+		_playButton.SetActive(false);
+		_quitButton.SetActive(false);
+		_creditButton.SetActive(false);
+	}
+	public void OnExitCreditClic()
+	{
+		//_uiCredit.SetActive(false);
+		//_playButton.SetActive(true);
+		//_quitButton.SetActive(true);
+		//_creditButton.SetActive(true);
+	}
+	public IEnumerator PlayGameCoroutine()
+	{
+		_animatorPlay.SetBool("PlayClick",true);
+		_cancelImage.SetActive(true);
+		yield return new WaitForSeconds(8);
+		SceneManager.LoadSceneAsync("InGame");
+	}
+	public void ExitGame()
+	{
+		Application.Quit();
+	}
+	public void OnClic()
+	{
+		if (AudioManager.TryAndGetInstance(out AudioManager audioManager))
+			audioManager.PlayAudioEffect("Clic", gameObject.transform.position, 2);
+	}
+	public void PlayGame()
+	{
+		StartCoroutine(PlayGameCoroutine());
+	}
 }

--- a/Assets/Scripts/WorldComponent/Level.cs
+++ b/Assets/Scripts/WorldComponent/Level.cs
@@ -16,7 +16,7 @@ public class Level : MonoBehaviour
 	private float			_rotationDuration = 0.2f;
 	/// <summary>The GameOBject that will be rotated.</summary>
 	[SerializeField]
-	private GameObject		_rotableChild;
+	private Transform		_rotableChild;
 	/// <summary>The material that has the storm effect</summary>
 	[SerializeField]
 	private Material		_stormEffect;
@@ -41,7 +41,7 @@ public class Level : MonoBehaviour
 			return ;
 		}
 		_instance = this;
-		_rotationGoal = _rotableChild.transform.rotation;
+		_rotationGoal = _rotableChild.rotation;
 		_storms = GetComponentsInChildren<Storm>();
 		_averageStormDistanceAtStart = GetAverageStormDistance();
 		_rigidBodys = GetComponentsInChildren<Rigidbody2D>();
@@ -90,7 +90,7 @@ public class Level : MonoBehaviour
 	private IEnumerator	RotateLevelToRotationGoal()
 	{
 		
-		yield return TransformUtils.RotateInTime(_rotableChild.transform, _rotationGoal, _rotationDuration);
+		yield return TransformUtils.RotateInTime(_rotableChild, _rotationGoal, _rotationDuration);
 		StartRigidbodysSimulation();
 		_rotateCoroutine = null;
 	}
@@ -143,5 +143,10 @@ public class Level : MonoBehaviour
 		StopRigidbodysSimulationInGrid();
 		_rotationGoal *= Quaternion.Euler(-axisValue * _rotationAngle * Vector3.forward);
 		_rotateCoroutine = StartCoroutine(RotateLevelToRotationGoal());
+	}
+	
+	public Transform	GetRotableChild()
+	{
+		return (_rotableChild);
 	}
 }

--- a/Assets/Scripts/WorldComponent/Shock.cs
+++ b/Assets/Scripts/WorldComponent/Shock.cs
@@ -12,7 +12,7 @@ public class Shock : MonoBehaviour
 	/// <summary>The event that is called on shock. It should take a GameObject has
 	/// his unique parameter.</summary>
 	[SerializeField]
-	private UnityEvent<GameObject>	_onShock;
+	private UnityEvent<Transform>	_onShock;
 
 	private Rigidbody2D				_rigidbody;
 	private Vector2					_previousVelocity;
@@ -27,7 +27,7 @@ public class Shock : MonoBehaviour
 	{
 		float velocityDiff = _previousVelocity.magnitude - _rigidbody.linearVelocity.magnitude;
 		if (velocityDiff > _minVelocityDiffToShock)
-			_onShock.Invoke(gameObject);
+			_onShock.Invoke(transform);
 		_previousVelocity = _rigidbody.linearVelocity;
 	}
 }


### PR DESCRIPTION
Fixed a bug where instanciated objects where instanciated outside the rotable child of the level. They were not moving with the levels. It impacted the events (pollos falling and box falling), and the AudioManager.

Added a getter for the _rotableChild of the level so that scripts can instantiate in the rotable script.

Events and AudioManager now instantiate in the rotableChild.

Added an InstantiateTemporaryEffect in the vents to instantiate and destroy after a delay, the effect.